### PR TITLE
fix: renamed vim.loop to vim.uv

### DIFF
--- a/lua/cmp_dictionary/util.lua
+++ b/lua/cmp_dictionary/util.lua
@@ -1,4 +1,4 @@
-local uv = vim.loop
+local uv = vim.uv or vim.loop
 
 local M = {}
 


### PR DESCRIPTION
Fixed an error in Neovim's HEAD due to a function change.

ref: https://github.com/neovim/neovim/pull/22846

```
Error executing luv callback:
...mp-dictionary/lua/cmp_dictionary/kit/Async/AsyncTask.lua:223: ...are/nvim/lazy/cmp-dictionary/lua/cmp_dictionary/util.lua:10: attempt to index upvalue 'uv' (a nil value)
stack traceback:
	[C]: in function 'error'
	...mp-dictionary/lua/cmp_dictionary/kit/Async/AsyncTask.lua:201: in function 'on_next'
	...mp-dictionary/lua/cmp_dictionary/kit/Async/AsyncTask.lua:223: in function 'dispatch'
	...mp-dictionary/lua/cmp_dictionary/kit/Async/AsyncTask.lua:234: in function 'c'
	...mp-dictionary/lua/cmp_dictionary/kit/Async/AsyncTask.lua:24: in function 'settle'
	...mp-dictionary/lua/cmp_dictionary/kit/Async/AsyncTask.lua:136: in function 'reject'
	.../cmp-dictionary/lua/cmp_dictionary/kit/Thread/Worker.lua:48: in function <.../cmp-dictionary/lua/cmp_dictionary/kit/Thread/Worker.lua:46>
	[C]: in function 'nvim_exec2'
	vim/_editor.lua: in function 'cmd'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:473: in function <...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:472>
	[C]: in function 'xpcall'
	.../.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/util.lua:110: in function 'try'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:472: in function 'source'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:431: in function 'source_runtime'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:399: in function 'packadd'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:335: in function '_load'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:184: in function 'load'
	...hare/nvim/lazy/lazy.nvim/lua/lazy/core/handler/event.lua:33: in function <...hare/nvim/lazy/lazy.nvim/lua/lazy/core/handler/event.lua:26>
	[C]: in function 'nvim_exec_autocmds'
	.../.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/util.lua:149: in function <.../.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/util.lua:144>
```