### PR TITLE
fix(utils): format job.new's result to a string

### DIFF
--- a/lua/cmp_dictionary/util.lua
+++ b/lua/cmp_dictionary/util.lua
@@ -23,6 +23,9 @@ function M.system(command)
         result = j:result()
       end,
     }):sync()
+    if (type(result) == "table") then
+      result = table.concat(result, "\n")
+    end
     return result
   end
 end


### PR DESCRIPTION
job.new returns an array of strings (stdout from the command), but cmp expects a string, or a table of value: string, and kind: string. This pr changes the output of utils.system to match expected input of cmp.

closes #61 